### PR TITLE
doc: fix uv_get_free_memory doc

### DIFF
--- a/docs/src/misc.rst
+++ b/docs/src/misc.rst
@@ -431,7 +431,10 @@ API
 
     .. versionadded:: 1.9.0
 
-.. uint64_t uv_get_free_memory(void)
+.. c:function:: uint64_t uv_get_free_memory(void)
+
+    Gets memory information (in bytes).
+
 .. c:function:: uint64_t uv_get_total_memory(void)
 
     Gets memory information (in bytes).


### PR DESCRIPTION
There was a formatting error that prevented the uv_get_free_memory function from appearing on the page